### PR TITLE
Makefile: Update tools and targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: go
 go:
 - "1.12.4"
 
+env:
+  GO111MODULE=off
+
 install:
 - make tools
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: false
 language: go
 go:
-- "1.10.1"
+- "1.12.4"
 
 install:
 - make tools

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,9 @@ integration:
 tools:
 	go get -u github.com/robertkrimen/godocdown/godocdown
 	go get -u github.com/kardianos/govendor
-	go get -u honnef.co/go/tools/cmd/gosimple
-	go get -u honnef.co/go/tools/cmd/unused
-	go get -u honnef.co/go/tools/cmd/staticcheck
+	go get -u honnef.co/go/tools/staticcheck
 	go get -u github.com/client9/misspell/cmd/misspell
-	go get -u github.com/golang/lint/golint
+	go get -u golang.org/x/lint/golint
 
 vendor-status:
 	@govendor status
@@ -32,7 +30,7 @@ lint:
 	@echo -e "$(OK_MSG)"
 
 # check combines all checks into a single command
-check: fmtcheck vet misspell staticcheck simple unused lint vendor-status
+check: fmtcheck vet misspell staticcheck lint vendor-status
 
 # fmt formats Go code.
 fmt:
@@ -47,11 +45,6 @@ webdoc:
 	@sleep 1 && open http://localhost:6060 &
 	@godoc -http=:6060
 
-unused:
-	@echo -n "==> Checking that code complies with unused requirements..."
-	@unused $(GOLIST)
-	@echo -e "$(OK_MSG)"
-
 fmtcheck:
 	@echo -n "==> Checking that code complies with gofmt requirements..."
 	@gofmt_files=$$(gofmt -l $(GOFMT_FILES)) ; if [[ -n "$$gofmt_files" ]]; then \
@@ -65,11 +58,6 @@ fmtcheck:
 misspell:
 	@echo -n "==> Checking for misspelling errors..."
 	@misspell --error $(GOFMT_FILES)
-	@echo -e "$(OK_MSG)"
-
-simple:
-	@echo -n "==> Checking that code complies with gosimple requirements..."
-	@gosimple $(GOLIST)
 	@echo -e "$(OK_MSG)"
 
 staticcheck:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ integration:
 tools:
 	go get -u github.com/robertkrimen/godocdown/godocdown
 	go get -u github.com/kardianos/govendor
-	go get -u honnef.co/go/tools/staticcheck
+	go get -u honnef.co/go/tools/cmd/staticcheck
 	go get -u github.com/client9/misspell/cmd/misspell
 	go get -u golang.org/x/lint/golint
 


### PR DESCRIPTION
Remove `gosimple` and `unused` tools and targets as they are now
integrated into `staticcheck`

### Tests
```
⇒  make
==> Checking that code complies with gofmt requirements... ✔
==> Checking that code complies with go vet requirements... ✔
==> Checking for misspelling errors... ✔
==> Checking that code complies with staticcheck requirements... ✔
==> Checking that code complies with golint requirements... ✔
==> Checking that code complies with unit tests...
ok      github.com/heimweh/go-pagerduty/pagerduty       0.050s  coverage: 77.5% of statements
```